### PR TITLE
Use dot to access the args builtin

### DIFF
--- a/src/pages/one-liners.md
+++ b/src/pages/one-liners.md
@@ -4,22 +4,22 @@ The following one-liners demonstrate different capabilities:
 
 ```
 # Files opened by thread name
-bpftrace -e 'tracepoint:syscalls:sys_enter_open { printf("%s %s\n", comm, str(args->filename)); }'
+bpftrace -e 'tracepoint:syscalls:sys_enter_open { printf("%s %s\n", comm, str(args.filename)); }'
 
 # Syscall count by thread name
 bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
 
 # Read bytes by thread name:
-bpftrace -e 'tracepoint:syscalls:sys_exit_read /args->ret/ { @[comm] = sum(args->ret); }'
+bpftrace -e 'tracepoint:syscalls:sys_exit_read /args.ret/ { @[comm] = sum(args.ret); }'
 
 # Read size distribution by thread name:
-bpftrace -e 'tracepoint:syscalls:sys_exit_read { @[comm] = hist(args->ret); }'
+bpftrace -e 'tracepoint:syscalls:sys_exit_read { @[comm] = hist(args.ret); }'
 
 # Show per-second syscall rates:
 bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @ = count(); } interval:s:1 { print(@); clear(@); }'
 
 # Trace disk size by PID and thread name
-bpftrace -e 'tracepoint:block:block_rq_issue { printf("%d %s %d\n", pid, comm, args->bytes); }'
+bpftrace -e 'tracepoint:block:block_rq_issue { printf("%d %s %d\n", pid, comm, args.bytes); }'
 
 # Count page faults by thread name
 bpftrace -e 'software:faults:1 { @[comm] = count(); }'
@@ -31,7 +31,7 @@ bpftrace -e 'hardware:cache-misses:1000000 { @[comm, pid] = count(); }'
 bpftrace -e 'profile:hz:99 /pid == 189/ { @[ustack] = count(); }'
 
 # Files opened in the root cgroup-v2
-bpftrace -e 'tracepoint:syscalls:sys_enter_openat /cgroup == cgroupid("/sys/fs/cgroup/unified/mycg")/ { printf("%s\n", str(args->filename)); }'
+bpftrace -e 'tracepoint:syscalls:sys_enter_openat /cgroup == cgroupid("/sys/fs/cgroup/unified/mycg")/ { printf("%s\n", str(args.filename)); }'
 ```
 
 [**One Liner Tutorial**](./tutorial-one-liners)


### PR DESCRIPTION
It's been a while since `args->xxx` was deprecated, do not use it in the oneliners tutorial.