### PR TITLE
Fix sync docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,19 +150,27 @@ const config = {
             to: '/docs/release_023/docs',
             items: [
               {
-                label: 'pre-release',
+                label: 'The Language',
+                to: '/docs/release_023/language'
+              },
+              {
+                label: 'The Standard Library',
+                to: '/docs/release_023/stdlib'
+              },
+              {
+                label: 'The Command Line Tool',
+                to: '/docs/release_023/cli'
+              },
+               {
+                label: 'Pre-release docs',
                 to: '/docs/pre-release/docs'
               },
               {
-                label: '0.23 (latest)',
-                to: '/docs/release_023/docs'
-              },
-              {
-                label: '0.22',
+                label: '0.22 docs',
                 to: '/docs/0.22'
               },
               {
-                label: '0.21',
+                label: '0.21 docs',
                 to: '/docs/0.21'
               },
             ],

--- a/make-doc.js
+++ b/make-doc.js
@@ -5,7 +5,7 @@
  * via this command:
  * `asciidoctor man/adoc/bpftrace.adoc -b html5 -o adoc.html`
  * and transforms it into a js file for the bpftrace website's docs section.
- * 
+ *
  * Usage:
  * `./make-doc.js adoc.html 0.22` - to make docs from version 0.22
  * `./make-doc.js adoc.html` - to make the unreleased/master docs
@@ -34,27 +34,29 @@ const PRE_CURLY_END = "`}</pre>"
 
 var body = []
 var toc = []
-const destinationPath = path.join(
-	__dirname,
-	'/src/pages/docs/',
-	versionArg + '.js')
-	
+
 function replaceCodeSnippetWord(str) {
 	return str.replaceAll("\\n", "\\\\n")
 		  .replaceAll("\\0", "\\\\0")
 		  .replaceAll("&gt;", ">")
 		  .replaceAll("&lt;", "<");
-		  
+
 }
 
 async function processAdoc() {
+
+	const destinationPath = path.join(
+		__dirname,
+		'/src/pages/docs/',
+		versionArg + '/cli.js');
+
 	const fileStream = createReadStream(filePath);
 
 	const rl = createInterface({
 		input: fileStream,
 		crlfDelay: Infinity,
 	});
-	
+
 	var insideToc = false;
 	var insideBody = false;
 	var insidePre = false;
@@ -62,7 +64,7 @@ async function processAdoc() {
 	for await (var line of rl) {
 		if (line.includes("<ul class=\"sectlevel1\">")) {
 			insideToc = true;
-			toc.push("<ul className=\"sectlevel1\">");
+			toc.push("<ul className=\"table-of-contents table-of-contents__left-border\">");
 			continue;
 		}
 		if (line.includes("<div id=\"content\">")) {
@@ -79,7 +81,7 @@ async function processAdoc() {
 			if (line.includes("<div id=\"footer\">")) {
 				break;
 			}
-			
+
 			if (line.includes("<pre")) {
 				if (line.includes(PRE_END)) {
 					body.push(
@@ -94,7 +96,7 @@ async function processAdoc() {
 				let idx = line.lastIndexOf('>');
 				line = PRE_CURLY_START + line.substring(idx + 1);
 			}
-			
+
 			if (line.startsWith("<col ") || line === "<col>") {
 				body.push("<col />")
 			} else {
@@ -111,36 +113,90 @@ async function processAdoc() {
 						.replace(/{/ig, "&#123;")
 						.replace(/}/ig, "&#125;")
 						.replace(/class="/ig, "className=\"")
+						.replaceAll("https://github.com/bpftrace/bpftrace/blob/master/docs/language.md", "language")
+						.replaceAll("https://github.com/bpftrace/bpftrace/blob/master/docs/stdlib.md", "stdlib")
 						);
 				}
 			}
-			
+
 		}
 	}
-	
+
 	fs.readFile(templatePath, {encoding: 'utf-8'}, function(err, data){
 		if (err) {
 			console.error("Error reading js template at path: ", templatePath);
 			console.error(err);
 			return;
 		}
-		
-		const versionHeader = "<h1>Version: " + versionArg + "</h1>"
+
+		const versionHeader = "<h1>The Command Line Tool (" + versionArg + ")</h1>"
 		var versionPage = data.replace("<div id=\"version-content\" />", versionHeader)
 				.replace("<div id=\"body-content\" />", body.join("\n"))
 				.replace("<div id=\"toc-content\" />", toc.join("\n"))
-		
+
 		fs.writeFile(destinationPath, versionPage, err => {
 			if (err) {
 				console.error("Error writing new version doc to path: ", destinationPath);
 			  	console.error(err);
 				return;
 			}
-			
+
 			console.log("Success.");
 			console.log("Wrote: ", destinationPath);
 		});
 	});
 }
 
+async function processMarkdownDoc(filename) {
+
+	const filePath = path.join(
+		__dirname,
+		'/bpftrace/docs/',
+		filename);
+
+	const destinationPath = path.join(
+		__dirname,
+		'/src/pages/docs/',
+		versionArg,
+		'/',
+		filename)
+
+	const fileStream = createReadStream(filePath);
+
+	const rl = createInterface({
+		input: fileStream,
+		crlfDelay: Infinity,
+	});
+
+	const newLines = [];
+	let firstLine = true;
+
+	for await (var line of rl) {
+		if (firstLine) {
+			newLines.push(line + ' (' + versionArg + ')');
+			firstLine = false;
+			continue;
+		}
+		newLines.push(
+			line
+			.replaceAll("../man/adoc/bpftrace.adoc", "cli")
+			.replaceAll("stdlib.md", "stdlib")
+			.replaceAll("language.md", "language")
+		);
+	}
+
+	fs.writeFile(destinationPath, newLines.join('\n'), err => {
+		if (err) {
+			console.error("Error writing to path: ", destinationPath);
+			console.error(err);
+			return;
+		}
+
+		console.log("Success.");
+		console.log("Wrote: ", destinationPath);
+	});
+}
+
 processAdoc();
+processMarkdownDoc("language.md");
+processMarkdownDoc("stdlib.md");

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "make-pre-release-docs": "asciidoctor bpftrace/man/adoc/bpftrace.adoc -b html5 -o adoc.html && ./make-doc.js adoc.html",
-    "main-docs-sync": "asciidoctor ${npm_config_adoc} -b html5 -o adoc.html && ./make-doc.js adoc.html"
+    "make-pre-release-docs": "asciidoctor bpftrace/man/adoc/bpftrace.adoc -b html5 -o adoc.html && ./make-doc.js adoc.html"
   },
   "dependencies": {
     "@docusaurus/core": "3.6.3",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -15,7 +15,6 @@
   --ifm-color-primary-lightest: #f1d366;
 
   --ifm-link-color: #307D77;
-  --docs-header-height: 5rem;
 }
 
 
@@ -103,34 +102,21 @@
   --ifm-footer-background-color: #18252D;
 }
 
-#docs-header {
-  height: var(--docs-header-height);
-}
-
-.docs-container h2  {
-  scroll-margin-top: calc(var(--ifm-navbar-height) + .5rem);
-}
-
-.docs-container h3 {
-  --ifm-h3-font-size: 1.5rem;
-  margin-top: calc(var(--ifm-h3-vertical-rhythm-top)* var(--ifm-leading));
-  scroll-margin-top: calc(var(--ifm-navbar-height) + .5rem);
+.docs-left-col h2,
+.docs-left-col h3,
+.docs-left-col h4 {
+  scroll-margin-top: calc(var(--ifm-navbar-height) + 0.5rem);
 }
 
 .docs-toc {
   max-height: calc(100vh - var(--ifm-navbar-height) - 2rem);
   overflow-y: auto;
   position: sticky;
-  top: calc(var(--ifm-navbar-height) + var(--docs-header-height) + 1rem);
-}
-
-.docs-toc ul {
-  list-style: none;
-  padding-left: var(--ifm-toc-padding-horizontal);
+  top: calc(var(--ifm-navbar-height) + 1rem);
 }
 
 .docs-row {
-  flex-direction: row-reverse;
+  justify-content: center;
 }
 
 .video-row {
@@ -154,10 +140,10 @@
   color: #1c1e21;
 }
 
-@media (min-width: 997px) {
+@media (max-width: 997px) {
 
-  .docs-left-col {
-    max-width: 75% !important;
+  .docs-row .col--2 {
+    display: none ;
   }
 
 }

--- a/src/pages/docs/0.21.js
+++ b/src/pages/docs/0.21.js
@@ -11,34 +11,10 @@ import styles from '../index.module.css';
 export default function Home() {
   return (
     <Layout title="docs">
-	    <div className="container docs-container padding-top--md padding-bottom--lg">
-      <div id="docs-header">
-              <h1>Version: 0.21</h1>
-            </div>
+	    <div className="container container--fluid margin-vert--lg">
         <div className="row docs-row">
-        <div className="col col--3">
-            <div className="docs-toc">
-            <ul className="sectlevel1">
-<li><a href="#_synopsis">Synopsis</a></li>
-<li><a href="#_description">Description</a></li>
-<li><a href="#_examples">Examples</a></li>
-<li><a href="#_supported_architectures">Supported architectures</a></li>
-<li><a href="#_options">Options</a></li>
-<li><a href="#_terminology">Terminology</a></li>
-<li><a href="#_program_files">Program Files</a></li>
-<li><a href="#_bpftrace_language">bpftrace Language</a></li>
-<li><a href="#_builtins">Builtins</a></li>
-<li><a href="#_functions">Functions</a></li>
-<li><a href="#_map_functions">Map Functions</a></li>
-<li><a href="#_probes">Probes</a></li>
-<li><a href="#_config_variables">Config Variables</a></li>
-<li><a href="#_environment_variables">Environment Variables</a></li>
-<li><a href="#_options_expanded">Options Expanded</a></li>
-<li><a href="#_advanced_topics">Advanced Topics</a></li>
-</ul>
-            </div>
-          </div>
-          <div className="col docs-left-col">
+          <div className="col docs-left-col col--8">
+          <h1>Documentation (Version: 0.21)</h1>
             <div id="content">
 <div className="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -5462,6 +5438,28 @@ until bpftrace started by the systemd unit has attached its probes.</p>
 </div>
 </div>
           </div>
+          <div className="col col--2">
+          <div className="docs-toc">
+            <ul className="table-of-contents table-of-contents__left-border">
+<li><a href="#_synopsis">Synopsis</a></li>
+<li><a href="#_description">Description</a></li>
+<li><a href="#_examples">Examples</a></li>
+<li><a href="#_supported_architectures">Supported architectures</a></li>
+<li><a href="#_options">Options</a></li>
+<li><a href="#_terminology">Terminology</a></li>
+<li><a href="#_program_files">Program Files</a></li>
+<li><a href="#_bpftrace_language">bpftrace Language</a></li>
+<li><a href="#_builtins">Builtins</a></li>
+<li><a href="#_functions">Functions</a></li>
+<li><a href="#_map_functions">Map Functions</a></li>
+<li><a href="#_probes">Probes</a></li>
+<li><a href="#_config_variables">Config Variables</a></li>
+<li><a href="#_environment_variables">Environment Variables</a></li>
+<li><a href="#_options_expanded">Options Expanded</a></li>
+<li><a href="#_advanced_topics">Advanced Topics</a></li>
+</ul>
+            </div>
+            </div>
         </div>
       </div>
     </Layout>

--- a/src/pages/docs/0.22.js
+++ b/src/pages/docs/0.22.js
@@ -11,34 +11,10 @@ import styles from '../index.module.css';
 export default function Home() {
   return (
     <Layout title="docs">
-	    <div className="container docs-container padding-top--md padding-bottom--lg">
-        <div id="docs-header">
-          <h1>Version: 0.22</h1>
-        </div>
+	    <div className="container container--fluid margin-vert--lg">
         <div className="row docs-row">
-          <div className="col col--3">
-            <div className="docs-toc">
-              <ul className="sectlevel1">
-<li><a href="#_synopsis">Synopsis</a></li>
-<li><a href="#_description">Description</a></li>
-<li><a href="#_examples">Examples</a></li>
-<li><a href="#_supported_architectures">Supported architectures</a></li>
-<li><a href="#_options">Options</a></li>
-<li><a href="#_terminology">Terminology</a></li>
-<li><a href="#_program_files">Program Files</a></li>
-<li><a href="#_bpftrace_language">bpftrace Language</a></li>
-<li><a href="#_builtins">Builtins</a></li>
-<li><a href="#_functions">Functions</a></li>
-<li><a href="#_map_functions">Map Functions</a></li>
-<li><a href="#_probes">Probes</a></li>
-<li><a href="#_config_variables">Config Variables</a></li>
-<li><a href="#_environment_variables">Environment Variables</a></li>
-<li><a href="#_options_expanded">Options Expanded</a></li>
-<li><a href="#_advanced_topics">Advanced Topics</a></li>
-</ul>
-            </div>
-          </div>
-          <div className="col docs-left-col">
+          <div className="col docs-left-col col--8">
+          <h1>Documentation (Version: 0.22)</h1>
             <div id="content">
 <div className="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -5913,6 +5889,28 @@ during comparisons, <code>printf()</code>, or other.</p>
 </div>
 </div>
           </div>
+          <div className="col col--2">
+          <div className="docs-toc">
+            <ul className="table-of-contents table-of-contents__left-border">
+<li><a href="#_synopsis">Synopsis</a></li>
+<li><a href="#_description">Description</a></li>
+<li><a href="#_examples">Examples</a></li>
+<li><a href="#_supported_architectures">Supported architectures</a></li>
+<li><a href="#_options">Options</a></li>
+<li><a href="#_terminology">Terminology</a></li>
+<li><a href="#_program_files">Program Files</a></li>
+<li><a href="#_bpftrace_language">bpftrace Language</a></li>
+<li><a href="#_builtins">Builtins</a></li>
+<li><a href="#_functions">Functions</a></li>
+<li><a href="#_map_functions">Map Functions</a></li>
+<li><a href="#_probes">Probes</a></li>
+<li><a href="#_config_variables">Config Variables</a></li>
+<li><a href="#_environment_variables">Environment Variables</a></li>
+<li><a href="#_options_expanded">Options Expanded</a></li>
+<li><a href="#_advanced_topics">Advanced Topics</a></li>
+</ul>
+            </div>
+            </div>
         </div>
       </div>
     </Layout>

--- a/src/pages/docs/__template.js
+++ b/src/pages/docs/__template.js
@@ -6,23 +6,21 @@ import HomepageFeatures from '@site/src/components/HomepageFeatures';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import Heading from '@theme/Heading';
-import styles from '../index.module.css';
+import styles from '../../index.module.css';
 
 export default function Home() {
   return (
     <Layout title="docs">
-	    <div className="container docs-container padding-top--md padding-bottom--lg">
-        <div id="docs-header">
-          <div id="version-content" />
-        </div>
+      <div className="container container--fluid margin-vert--lg">
         <div className="row docs-row">
-          <div className="col col--3">
+          <div className="col docs-left-col col--8">
+            <div id="version-content" />
+            <div id="body-content" />
+          </div>
+          <div className="col col--2">
             <div className="docs-toc">
               <div id="toc-content" />
             </div>
-          </div>
-          <div className="col docs-left-col">
-            <div id="body-content" />
           </div>
         </div>
       </div>

--- a/src/pages/docs/pre-release/cli.js
+++ b/src/pages/docs/pre-release/cli.js
@@ -11,26 +11,10 @@ import styles from '../../index.module.css';
 export default function Home() {
   return (
     <Layout title="docs">
-	    <div className="container docs-container padding-top--md padding-bottom--lg">
-        <div id="docs-header">
-          <h1>The Command Line Tool (pre-release)</h1>
-        </div>
+      <div className="container container--fluid margin-vert--lg">
         <div className="row docs-row">
-          <div className="col col--3">
-            <div className="docs-toc">
-              <ul className="sectlevel1">
-<li><a href="#_synopsis">Synopsis</a></li>
-<li><a href="#_description">Description</a></li>
-<li><a href="#_examples">Examples</a></li>
-<li><a href="#_options">Options</a></li>
-<li><a href="#_configuration">Configuration</a></li>
-<li><a href="#_options_expanded">Options Expanded</a></li>
-<li><a href="#_terminology">Terminology</a></li>
-<li><a href="#_program_files">Program Files</a></li>
-</ul>
-            </div>
-          </div>
-          <div className="col docs-left-col">
+          <div className="col docs-left-col col--8">
+            <h1>The Command Line Tool (pre-release)</h1>
             <div id="content">
 <div className="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -325,8 +309,35 @@ Positional parameters can be placed before or after a double dash but named para
 <div className="paragraph">
 <p>In these examples there are two positional parameters (<code>p1</code>, <code>p2</code>) and two named parameters (<code>aa</code>, which is set to <code>20</code>, and <code>bb</code>, which is set to <code>true</code>).
 Named program parameters require the <code>=</code> to set their value unless they are boolean parameters (like 'bb' above).
-Read about how to access <a href="#builtins-positional-parameters">positional</a> or <a href="#functions-getopt">named</a> parameters in a bpftrace script below.</p>
+Read about how to access positional and named parameters <a href="language#command-line-parameters">here</a>.</p>
 </div>
+</div>
+</div>
+</div>
+<div className="sect1">
+<h2 id="_the_language">The Language</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>Syntax, types, and concepts for bpftrace are <a href="language">available here</a>.</p>
+</div>
+</div>
+</div>
+<div className="sect1">
+<h2 id="_probes">Probes</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>bpftrace supports various probe types which allow the user to attach BPF programs to different types of events.
+Each probe starts with a provider (e.g. <code>kprobe</code>) followed by a colon (<code>:</code>) separated list of options.
+The amount of options and their meaning depend on the provider.
+<a href="language#probes">Full list of probe types</a>.</p>
+</div>
+</div>
+</div>
+<div className="sect1">
+<h2 id="_standard_library">Standard library</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>The standard library of all <a href="stdlib#builtins">builtins</a>, <a href="stdlib#functions">functions</a>, and <a href="stdlib#map-functions">map functions</a> is <a href="stdlib">available here</a>.</p>
 </div>
 </div>
 </div>
@@ -336,15 +347,14 @@ Read about how to access <a href="#builtins-positional-parameters">positional</a
 <div className="sect2">
 <h3 id="_config_variables">Config Variables</h3>
 <div className="paragraph">
-<p>Some behavior can only be controlled through config variables, which are <a href="./language#config-variables">listed here</a>.
-These can be set via the Config Block directly in a script (before any probes) or via their environment variable equivalent, which is upper case and includes the `BPFTRACE_` prefix e.g. ``stack_mode``'s environment variable would be `BPFTRACE_STACK_MODE`.</p>
+<p>Some behavior can only be controlled through config variables, which are <a href="language#config-variables">available here</a>.
+These can be set via the Config Block directly in a script (before any probes) or via their environment variable equivalent, which is upper case and includes the <code>BPFTRACE_</code> prefix e.g. <code>stack_mode</code>'s environment variable would be <code>BPFTRACE_STACK_MODE</code>.</p>
 </div>
-
 </div>
 <div className="sect2">
 <h3 id="_environment_variables">Environment Variables</h3>
 <div className="paragraph">
-<p>These are not available as part of the standard set of <a href="./language#config-variables">Config Variables</a> and can only be set as environment variables.</p>
+<p>These are not available as part of the standard set of Config Variables above and can only be set as environment variables.</p>
 </div>
 <div className="sect3">
 <h4 id="_bpftrace_btf">BPFTRACE_BTF</h4>
@@ -405,9 +415,12 @@ See src/attached_probe.cpp:find_vmlinux() for details.</p>
 </div>
 </div>
 </div>
-<div className="sect2">
+</div>
+</div>
+<div className="sect1">
 <h2 id="_options_expanded">Options Expanded</h2>
-<div className="sect3">
+<div className="sectionbody">
+<div className="sect2">
 <h3 id="_debug_output">Debug Output</h3>
 <div className="paragraph">
 <p>The <code>-d STAGE</code> option produces debug output. It prints the output of the
@@ -461,7 +474,7 @@ Only available in debug builds.</p></td>
 </tbody>
 </table>
 </div>
-<div className="sect3">
+<div className="sect2">
 <h3 id="_listing_probes">Listing Probes</h3>
 <div className="paragraph">
 <p>Probe listing is the method to discover which probes are supported by the current system.
@@ -517,7 +530,7 @@ struct css_task_iter {
 </div>
 </div>
 </div>
-<div className="sect3">
+<div className="sect2">
 <h3 id="_preprocessor_options">Preprocessor Options</h3>
 <div className="paragraph">
 <p>The <code>-I</code> option can be used to add directories to the list of directories that bpftrace uses to look for headers.
@@ -559,7 +572,7 @@ open path: .com.google.Chrome.R1234s`}</pre>
 </div>
 </div>
 </div>
-<div className="sect3">
+<div className="sect2">
 <h3 id="_verbose_output">Verbose Output</h3>
 <div className="paragraph">
 <p>The <code>-v</code> option prints more information about the program as it is run:</p>
@@ -577,7 +590,6 @@ Attaching tracepoint:syscalls:sys_enter_nanosleep
 iscsid is sleeping.
 iscsid is sleeping.
 [...]`}</pre>
-</div>
 </div>
 </div>
 </div>
@@ -700,6 +712,23 @@ iscsid is sleeping.`}</pre>
 </div>
 </div>
 </div>
+          </div>
+          <div className="col col--2">
+            <div className="docs-toc">
+              <ul className="table-of-contents table-of-contents__left-border">
+<li><a href="#_synopsis">Synopsis</a></li>
+<li><a href="#_description">Description</a></li>
+<li><a href="#_examples">Examples</a></li>
+<li><a href="#_options">Options</a></li>
+<li><a href="#_the_language">The Language</a></li>
+<li><a href="#_probes">Probes</a></li>
+<li><a href="#_standard_library">Standard library</a></li>
+<li><a href="#_configuration">Configuration</a></li>
+<li><a href="#_options_expanded">Options Expanded</a></li>
+<li><a href="#_terminology">Terminology</a></li>
+<li><a href="#_program_files">Program Files</a></li>
+</ul>
+            </div>
           </div>
         </div>
       </div>

--- a/src/pages/docs/pre-release/docs.js
+++ b/src/pages/docs/pre-release/docs.js
@@ -16,8 +16,8 @@ function DocsBody() {
     const [url, setUrl] = useState('https://www.youtube.com/watch?v=18xPsqYjUhE');
     return (
 <div className="container container--fluid margin-vert--lg">
-        <div className="row">
-        	<div className="col col--9">
+        <div className="row docs-row">
+        	<div className="col col--8">
 			<h1>Documentation (pre-release)</h1>
             <p>bpftrace documentation is divided into three sections. However for earlier bpftrace versions these sections are part of a single document, which are available in the dropdown.</p>
                 <div className="container container--fluid margin-vert--lg">
@@ -40,7 +40,7 @@ function DocsBody() {
                 </div>
                 </div>
           	</div>
-        	<div className="col col--3">
+        	<div className="col col--2">
 			<div class="dropdown dropdown--hoverable">
                 <button class="button button--primary releases-dropdown">pre-release</button>
                 <ul class="dropdown__menu">

--- a/src/pages/docs/pre-release/language.md
+++ b/src/pages/docs/pre-release/language.md
@@ -762,7 +762,7 @@ $b = --$a; // a = 9; b = 9
 Note that maps will be implicitly declared and initialized to 0 if not already declared or defined.
 Scratch variables must be initialized before using these operators.
 
-Note `++`/`--` on a shared global variable can lose updates. See [`count()`](./stdlib#count) for more details.
+Note `++`/`--` on a shared global variable can lose updates. See [`count()`](stdlib#count) for more details.
 
 ### Block Expressions
 
@@ -810,7 +810,7 @@ bpftrace supports various probe types which allow the user to attach BPF program
 Each probe starts with a provider (e.g. `kprobe`) followed by a colon (`:`) separated list of options.
 The amount of options and their meaning depend on the provider and are detailed below.
 The valid values for options can depend on the system or binary being traced, e.g. for uprobes it depends on the binary.
-Also see [Listing Probes](./cli#_listing_probes).
+Also see [Listing Probes](cli#listing-probes).
 
 It is possible to associate multiple probes with a single action as long as the action is valid for all specified probes.
 Multiple probes can be specified as a comma (`,`) separated list:
@@ -1113,7 +1113,7 @@ The original names are still supported for backwards compatibility.
 
 ``fentry``/``fexit`` probes make use of BTF type information to derive the type of function arguments at compile time.
 This removes the need for manual type casting and makes the code more resilient against small signature changes in the kernel.
-The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see [Listing Probes](./cli#_listing_probes)).
+The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see [Listing Probes](cli#listing-probes)).
 These arguments are also available in the return probe (`fexit`), unlike `kretprobe`.
 
 The bpf variants (e.g. `fentry:bpf[:prog_id]:prog_name`) allow attaching to running BPF programs and sub-programs.
@@ -1221,7 +1221,7 @@ kprobe:kvm:x86_emulate_insn
 }
 ```
 
-See [BTF Support](./language#btf-support) for more details.
+See [BTF Support](#btf-support) for more details.
 
 `kprobe` s are not limited to function entry, they can be attached to any instruction in a function by specifying an offset from the start of the function.
 
@@ -1291,7 +1291,7 @@ rawtracepoint:vmlinux:kfree_skb {
 `rawtracepoint` probes make use of BTF type information to derive the type of function arguments at compile time.
 This removes the need for manual type casting and makes the code more resilient against small signature changes in the kernel.
 The arguments accessible by a `rawtracepoint` are different from the arguments you can access from the `tracepoint` of the same name.
-The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see [Listing Probes](./cli#_listing_probes)).
+The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see [Listing Probes](cli#listing-probes)).
 
 ### software
 
@@ -1350,7 +1350,7 @@ tracepoint:syscalls:sys_enter_openat {
 }
 ```
 
-Tracepoint arguments are available in the `args` struct which can be inspected with verbose listing, see the [Listing Probes](./cli#_listing_probes) section for more details.
+Tracepoint arguments are available in the `args` struct which can be inspected with verbose listing, see the [Listing Probes](cli#listing-probes) section for more details.
 
 ```
 # bpftrace -lv "tracepoint:*"
@@ -1404,7 +1404,7 @@ a full path. The path will be then automatically resolved using `/etc/ld.so.cach
 uprobe:libc:malloc { printf("Allocated %d bytes\n", arg0); }
 ```
 
-If the traced binary has DWARF included, function arguments are available in the `args` struct which can be inspected with verbose listing, see the [Listing Probes](./cli#_listing_probes) section for more details.
+If the traced binary has DWARF included, function arguments are available in the `args` struct which can be inspected with verbose listing, see the [Listing Probes](cli#listing-probes) section for more details.
 
 ```
 # bpftrace -lv 'uprobe:/bin/bash:rl_set_prompt'
@@ -1843,7 +1843,7 @@ BEGIN { @=*uptr(kaddr("do_poweroff")) }
 ```
 
 bpftrace tries to automatically set the correct address space for a pointer based on the probe type, but might fail in cases where it is unclear.
-The address space can be changed with the [kptrs](./stdlib#kptr) and [uptr](./stdlib#uptr) functions.
+The address space can be changed with the [kptrs](stdlib#kptr) and [uptr](stdlib#uptr) functions.
 
 ### BPF License
 

--- a/src/pages/docs/pre-release/stdlib.md
+++ b/src/pages/docs/pre-release/stdlib.md
@@ -1,10 +1,5 @@
 # bpftrace Standard Library (pre-release)
 
-- [Builtins](#builtins)
-- [Functions](#functions)
-- [Map Functions](#map-functions)
-- [Invocation Mode](#invocation-mode)
-
 ## Builtins
 
 Builtins are special variables built into the language.
@@ -13,7 +8,7 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 
 | Variable | Type | BPF Helper | Description |
 | --- | --- | --- | --- |
-| [`$1`, `$2`, `...$n`](./language#positional-parameters) | int64 | n/a | The nth positional parameter passed to the bpftrace program. If less than n parameters are passed this evaluates to `0` in an action block or an empty string in a probe. For string arguments in an action block use the `str()` call to retrieve the value. |
+| [`$1`, `$2`, `...$n`](language#positional-parameters) | int64 | n/a | The nth positional parameter passed to the bpftrace program. If less than n parameters are passed this evaluates to `0` in an action block or an empty string in a probe. For string arguments in an action block use the `str()` call to retrieve the value. |
 | `$#` | int64 | n/a | Total amount of positional parameters passed. |
 | `arg0`, `arg1`, `...argn` | int64 | n/a | nth argument passed to the function being traced. These are extracted from the CPU registers. The amount of args passed in registers depends on the CPU architecture. (kprobes, uprobes, usdt). |
 | `args` | struct args | n/a | The struct of all arguments of the traced function. Available in `rawtracepoint`, `tracepoint`, `fentry`, `fexit`, and `uprobe` (with DWARF) probes. Use `args.x` to access argument `x` or `args` to get a record with all arguments. |
@@ -45,8 +40,6 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 | [`bswap`](#bswap) | Reverse byte order | Sync |
 | [`buf`](#buf) | Returns a hex-formatted string of the data pointed to by d | Sync |
 | [`cat`](#cat) | Print file content | Async |
-| [`pid`](#pid) | Process ID of the current thread | Sync |
-| [`tid`](#tid) | Thread ID of the current thread | Sync |
 | [`cgroupid`](#cgroupid) | Resolve cgroup ID | Compile Time |
 | [`cgroup_path`](#cgroup_path) | Convert cgroup id to cgroup path | Sync |
 | [`exit`](#exit) | Quit bpftrace with an optional exit code | Async |
@@ -64,6 +57,7 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 | [`override`](#override) | Override return value | Sync |
 | [`path`](#path) | Return full path | Sync |
 | [`percpu_kaddr`](#percpu_kaddr) | Resolve percpu kernel symbol name | Sync |
+| [`pid`](#pid) | Process ID of the current thread | Sync |
 | [`print`](#print) | Print a non-map value with default formatting | Async |
 | [`printf`](#printf) | Print formatted | Async |
 | [`pton`](#pton) | Convert text IP address to byte array | Compile Time |
@@ -78,6 +72,7 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 | [`strftime`](#strftime) | Return a formatted timestamp | Async |
 | [`strncmp`](#strncmp) | Compare first n characters of two strings | Sync |
 | [`system`](#system) | Execute shell command | Async |
+| [`tid`](#tid) | Thread ID of the current thread | Sync |
 | [`time`](#time) | Print formatted time | Async |
 | [`uaddr`](#uaddr) | Resolve user-level symbol name | Compile Time |
 | [`uptr`](#uptr) | Annotate as userspace pointer | Sync |
@@ -1225,7 +1220,7 @@ More information on [map printing](./language#map-printing).
 | [`clear`](#clear) | Clear all keys/values from a map. | Async |
 | [`count`](#count) | Count how often this function is called. | Sync |
 | [`delete`](#delete) | Delete a single key from a map. | Sync |
-| [`has_key`](#has_key) | Return true (1) if the key exists in this map. Otherwise return false (0). | Sync |
+| [`has_key`](#has_key) | Return true if the key exists in this map. Otherwise return false. | Sync |
 | [`hist`](#hist) | Create a log2 histogram of n using buckets per power of 2, 0 &lt;= k &lt;= 5, defaults to 0. | Sync |
 | [`len`](#len) | Return the number of elements in a map. | Sync |
 | [`lhist`](#lhist) | Create a linear histogram of n. lhist creates M ((max - min) / step) buckets in the range [min,max) where each bucket is step in size. | Sync |
@@ -1377,7 +1372,7 @@ kprobe:dummy {
 
 **variants**
 
-* `int has_key(map m, mapkey k)`
+* `boolean has_key(map m, mapkey k)`
 
 Return true (1) if the key exists in this map.
 Otherwise return false (0).

--- a/src/pages/docs/release_023/cli.js
+++ b/src/pages/docs/release_023/cli.js
@@ -11,26 +11,10 @@ import styles from '../../index.module.css';
 export default function Home() {
   return (
     <Layout title="docs">
-	    <div className="container docs-container padding-top--md padding-bottom--lg">
-        <div id="docs-header">
-          <h1>The Command Line Tool (Version: 0.23)</h1>
-        </div>
+	    <div className="container container--fluid margin-vert--lg">
         <div className="row docs-row">
-          <div className="col col--3">
-            <div className="docs-toc">
-              <ul className="sectlevel1">
-<li><a href="#_synopsis">Synopsis</a></li>
-<li><a href="#_description">Description</a></li>
-<li><a href="#_examples">Examples</a></li>
-<li><a href="#_options">Options</a></li>
-<li><a href="#_configuration">Configuration</a></li>
-<li><a href="#_options_expanded">Options Expanded</a></li>
-<li><a href="#_terminology">Terminology</a></li>
-<li><a href="#_program_files">Program Files</a></li>
-</ul>
-            </div>
-          </div>
-          <div className="col docs-left-col">
+          <div className="col docs-left-col col--8">
+          <h1>The Command Line Tool (Version: 0.23)</h1>
             <div id="content">
 <div className="sect1">
 <h2 id="_synopsis">Synopsis</h2>
@@ -331,12 +315,39 @@ Read about how to access <a href="#builtins-positional-parameters">positional</a
 </div>
 </div>
 <div className="sect1">
+<h2 id="_the_language">The Language</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>Syntax, types, and concepts for bpftrace are <a href="language">available here</a>.</p>
+</div>
+</div>
+</div>
+<div className="sect1">
+<h2 id="_probes">Probes</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>bpftrace supports various probe types which allow the user to attach BPF programs to different types of events.
+Each probe starts with a provider (e.g. <code>kprobe</code>) followed by a colon (<code>:</code>) separated list of options.
+The amount of options and their meaning depend on the provider.
+<a href="language#probes">Full list of probe types</a>.</p>
+</div>
+</div>
+</div>
+<div className="sect1">
+<h2 id="_standard_library">Standard library</h2>
+<div className="sectionbody">
+<div className="paragraph">
+<p>The standard library of all <a href="stdlib#builtins">builtins</a>, <a href="stdlib#functions">functions</a>, and <a href="stdlib#map-functions">map functions</a> is <a href="stdlib">available here</a>.</p>
+</div>
+</div>
+</div>
+<div className="sect1">
 <h2 id="_configuration">Configuration</h2>
 <div className="sectionbody">
 <div className="sect2">
 <h3 id="_config_variables">Config Variables</h3>
 <div className="paragraph">
-<p>Some behavior can only be controlled through config variables, which are <a href="./language#config-variables">listed here</a>.
+<p>Some behavior can only be controlled through config variables, which are <a href="language#config-variables">listed here</a>.
 These can be set via the Config Block directly in a script (before any probes) or via their environment variable equivalent, which is upper case and includes the `BPFTRACE_` prefix e.g. ``stack_mode``'s environment variable would be `BPFTRACE_STACK_MODE`.</p>
 </div>
 
@@ -344,7 +355,7 @@ These can be set via the Config Block directly in a script (before any probes) o
 <div className="sect2">
 <h3 id="_environment_variables">Environment Variables</h3>
 <div className="paragraph">
-<p>These are not available as part of the standard set of <a href="./language#config-variables">Config Variables</a> and can only be set as environment variables.</p>
+<p>These are not available as part of the standard set of <a href="language#config-variables">Config Variables</a> and can only be set as environment variables.</p>
 </div>
 <div className="sect3">
 <h4 id="_bpftrace_btf">BPFTRACE_BTF</h4>
@@ -701,7 +712,24 @@ iscsid is sleeping.`}</pre>
 </div>
 </div>
           </div>
-        </div>
+        <div className="col col--2">
+            <div className="docs-toc">
+              <ul className="table-of-contents table-of-contents__left-border">
+<li><a href="#_synopsis">Synopsis</a></li>
+<li><a href="#_description">Description</a></li>
+<li><a href="#_examples">Examples</a></li>
+<li><a href="#_options">Options</a></li>
+<li><a href="#_the_language">The Language</a></li>
+<li><a href="#_probes">Probes</a></li>
+<li><a href="#_standard_library">Standard library</a></li>
+<li><a href="#_configuration">Configuration</a></li>
+<li><a href="#_options_expanded">Options Expanded</a></li>
+<li><a href="#_terminology">Terminology</a></li>
+<li><a href="#_program_files">Program Files</a></li>
+</ul>
+</div>
+            </div>
+          </div>
       </div>
     </Layout>
   );

--- a/src/pages/docs/release_023/docs.js
+++ b/src/pages/docs/release_023/docs.js
@@ -16,8 +16,8 @@ function DocsBody() {
     const [url, setUrl] = useState('https://www.youtube.com/watch?v=18xPsqYjUhE');
     return (
 <div className="container container--fluid margin-vert--lg">
-        <div className="row">
-        	<div className="col col--9">
+        <div className="row docs-row">
+        	<div className="col col--8">
 			<h1>Documentation (Version: 0.23 - latest)</h1>
             <p>bpftrace documentation is divided into three sections. However for earlier bpftrace versions these sections are part of a single document, which are available in the dropdown.</p>
                 <div className="container container--fluid margin-vert--lg">
@@ -40,7 +40,7 @@ function DocsBody() {
                 </div>
                 </div>
           	</div>
-        	<div className="col col--3">
+        	<div className="col col--2">
 			<div class="dropdown dropdown--hoverable">
                 <button class="button button--primary releases-dropdown">0.23</button>
                 <ul class="dropdown__menu">

--- a/src/pages/docs/release_023/language.md
+++ b/src/pages/docs/release_023/language.md
@@ -1027,7 +1027,7 @@ kprobe:kvm:x86_emulate_insn
 }
 ```
 
-See [BTF Support](./language#btf-support) for more details.
+See [BTF Support](#btf-support) for more details.
 
 `kprobe` s are not limited to function entry, they can be attached to any instruction in a function by specifying an offset from the start of the function.
 

--- a/src/pages/docs/release_023/stdlib.md
+++ b/src/pages/docs/release_023/stdlib.md
@@ -1,10 +1,5 @@
 # bpftrace Standard Library (Version: 0.23)
 
-- [Builtins](#builtins)
-- [Functions](#functions)
-- [Map Functions](#map-functions)
-- [Invocation Mode](#invocation-mode)
-
 ## Builtins
 
 Builtins are special variables built into the language.
@@ -13,7 +8,7 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 
 | Variable | Type | BPF Helper | Description |
 | --- | --- | --- | --- |
-| [`$1`, `$2`, `...$n`](./language#positional-parameters) | int64 | n/a | The nth positional parameter passed to the bpftrace program. If less than n parameters are passed this evaluates to `0` in an action block or an empty string in a probe. For string arguments in an action block use the `str()` call to retrieve the value. |
+| [`$1`, `$2`, `...$n`](language#positional-parameters) | int64 | n/a | The nth positional parameter passed to the bpftrace program. If less than n parameters are passed this evaluates to `0` in an action block or an empty string in a probe. For string arguments in an action block use the `str()` call to retrieve the value. |
 | `$#` | int64 | n/a | Total amount of positional parameters passed. |
 | `arg0`, `arg1`, `...argn` | int64 | n/a | nth argument passed to the function being traced. These are extracted from the CPU registers. The amount of args passed in registers depends on the CPU architecture. (kprobes, uprobes, usdt). |
 | `args` | struct args | n/a | The struct of all arguments of the traced function. Available in `rawtracepoint`, `tracepoint`, `fentry`, `fexit`, and `uprobe` (with DWARF) probes. Use `args.x` to access argument `x` or `args` to get a record with all arguments. |
@@ -888,7 +883,7 @@ Prints:
 The maximum string length is limited by the `BPFTRACE_MAX_STRLEN` env variable, unless `length` is specified and shorter than the maximum.
 In case the string is longer than the specified length only `length - 1` bytes are copied and a NULL byte is appended at the end.
 
-When available (starting from kernel 5.5, see the `--info` flag) bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see [Address-spaces](./language#address-spaces) for more information.
+When available (starting from kernel 5.5, see the `--info` flag) bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see [Address-spaces](language#address-spaces) for more information.
 
 ### strcontains
 
@@ -1188,7 +1183,7 @@ The data type associated with these functions are only for internal use and are 
 
 Functions that are marked **async** are asynchronous which can lead to unexpected behavior, see the [Invocation Mode](#invocation-mode) section for more information.
 
-More information on [map printing](./language#map-printing).
+More information on [map printing](language#map-printing).
 
 | Name | Description | Sync/async |
 | --- | --- | --- |


### PR DESCRIPTION
The sync script now modifies
the language.md and stdlib.md docs
to link to the correct parts
of the other documentation pages.

Also update the style of the CLI doc
to match that of the other markdown doc
pages.